### PR TITLE
wrapping polygons all the same to be consistent

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ module.exports = function (collection, callback) {
     }
 
     if (isPolygon || isMultiPolygon) {
-      if (isPolygon) coords = [coords]
+      coords = [coords]
       loop(bbox, coords)
     }
   })

--- a/test/geojson-multi-spec-example.json
+++ b/test/geojson-multi-spec-example.json
@@ -72,7 +72,7 @@
     {
       "type": "Feature",
       "geometry": {
-        "type": "Polygon",
+        "type": "MultiPolygon",
         "coordinates": [
           [
             [


### PR DESCRIPTION
polygons and multipolys both get wrapped in an array to be consistently passed to `loop` just like the other geom types