### PR TITLE
Checking if the extent calculation is going to fail

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,9 @@ module.exports = function (collection, callback) {
     var coords = f.geometry.coordinates
 
     if (isPoint || isMultiPoint) {
+      if(Number.isNaN(coords[0]) || Number.isNaN(coords[1])){
+        console.warn(`Feature without geometries: ${JSON.stringify(f,null, 4)}`);
+      }
       if (isPoint) coords = [[[coords]]]
       else coords = [[coords]]
       loop(bbox, coords)


### PR DESCRIPTION
I was implementing a [Koop](http://koopjs.github.io) provider based on [this one](https://github.com/haoliangyu/koop-provider-csv) and got an `invalid extent passed in metadata` error message.

Debugging I found it was coming from [@koopjs/FeatureServer/geometry/extents.js](https://github.com/koopjs/FeatureServer/blob/master/src/geometry/extents.js#L9), called from [@koopjs/FeatureServer/src/templates.js](https://github.com/koopjs/FeatureServer/blob/master/src/templates.js#L43) which was using this (esri-extent) module and failing because I didn't realise the coordinates of a geometry had NaN values.

It was quite a painful process I had to go through, that's why I thought It would be nice to do this PR . :wink: 

Cheers,
Raul

